### PR TITLE
Recommend GUI flashing tools on homepage

### DIFF
--- a/PROMPT.log
+++ b/PROMPT.log
@@ -743,3 +743,4 @@ PROMPT: nice. the references to the iso in the docs need to be consistent with t
 PROMPT: occasionally (e.g. now) I will want to push updates to the github pages. Can you add support for doing that and then commit, push and publish the updates you have made
 PROMPT: well we cant have both the action deployment and the gh-pages branch so that is not going to work
 PROMPT.log
+2026-02-02 00:04:44 UTC - Updated homepage Flash & Boot step to recommend balenaEtcher/Ventoy as primary, dd as advanced option

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,9 +50,14 @@ cd tuinix && ./scripts/build-iso.sh
 Write the ISO to a USB drive and boot from it.
 UEFI is required -- disable Secure Boot.
 
-```bash
-sudo dd if={{ iso.filename }} of=/dev/sdX bs=4M status=progress
-```
+Use [balenaEtcher](https://etcher.balena.io/) or
+[Ventoy](https://www.ventoy.net/) to flash the ISO.
+
+??? tip "Advanced: using dd"
+
+    ```bash
+    sudo dd if={{ iso.filename }} of=/dev/sdX bs=4M status=progress
+    ```
 
 </div>
 


### PR DESCRIPTION
## Summary
- Recommend balenaEtcher and Ventoy as primary ISO flashing tools on the homepage
- Move `dd` command into a collapsible "Advanced" admonition for power users

## Test plan
- [ ] Verify homepage renders correctly with the collapsible dd section
- [ ] Confirm balenaEtcher and Ventoy links work