### PR TITLE
Remove obsolete README.txt validation from ISO build

### DIFF
--- a/PROMPT.log
+++ b/PROMPT.log
@@ -744,3 +744,4 @@ PROMPT: occasionally (e.g. now) I will want to push updates to the github pages.
 PROMPT: well we cant have both the action deployment and the gh-pages branch so that is not going to work
 PROMPT.log
 2026-02-02 00:04:44 UTC - Updated homepage Flash & Boot step to recommend balenaEtcher/Ventoy as primary, dd as advanced option
+2026-02-02 00:28:40 UTC - Removed obsolete README.txt validation check from build-iso.sh (file was deleted in previous session)

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -106,15 +106,6 @@ validate_iso() {
     validation_failed=1
   fi
 
-  # Check for installation README
-  if [[ -f "$mount_point/tuinix/README.txt" ]]; then
-    validation_results+=("✅ Installation README found")
-  else
-    validation_results+=("❌ Missing installation README")
-    validation_failed=1
-    eza --extended --tree --icons=always "$mount_point"
-  fi
-
   # Check for nix store
   if [[ -f "$mount_point/nix-store.squashfs" ]]; then
     validation_results+=("✅ Nix store found")


### PR DESCRIPTION
## Summary
- Remove the README.txt validation check from `scripts/build-iso.sh`
- The `README.txt` file was deleted when .github docs were consolidated into the mkdocs site, but the ISO validation still checked for it, causing build failures

## Test plan
- [ ] Build ISO with `./scripts/build-iso.sh` and verify validation passes without the README.txt check