### PR TITLE
Add multi-architecture ISO build support

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,332 @@
+# tuinix Specification
+
+This document provides a comprehensive specification of the tuinix project - a pure terminal-based Linux experience built on NixOS.
+
+## Overview
+
+tuinix is a NixOS-based distribution designed for users who prefer a terminal-only computing environment. It provides a reproducible, declarative system with ZFS encryption, offline installation support, and multi-architecture builds.
+
+## Supported Architectures
+
+| Architecture | ISO Name | Target Devices | Status |
+|--------------|----------|----------------|--------|
+| x86_64-linux | `tuinix.VERSION.x86_64.iso` | Standard PCs, laptops, servers | Fully supported |
+| aarch64-linux | `tuinix.VERSION.aarch64.iso` | ARM64 laptops, servers, SBCs with UEFI | Supported |
+
+### Architecture Notes
+
+- **x86_64**: Primary development platform. Includes ZFS support.
+- **aarch64**: Supports UEFI-capable ARM64 devices. ZFS excluded due to compatibility.
+- **R36S/Rockchip**: Planned support via SD card images (see `docs/r36s-build-notes.md`)
+
+## Installation Modes
+
+### Online Installation
+- Standard installation requiring network access
+- Downloads packages from cache.nixos.org during install
+- Smaller ISO size (~800MB)
+
+### Offline Installation
+- Full system closure included in ISO
+- No network required for standard configurations
+- Larger ISO size (~2-5GB)
+- Pre-cached packages include all tuinix features
+
+## System Features
+
+### Networking
+
+| Feature | Module | Default |
+|---------|--------|---------|
+| NetworkManager | `tuinix.networking.networkmanager` | Enabled |
+| iPhone USB Tethering | `tuinix.networking.iphone-tethering` | Enabled |
+| Wireless (wpa_supplicant) | `tuinix.networking.wireless` | Disabled |
+| Ethernet (systemd-networkd) | `tuinix.networking.ethernet` | Disabled |
+
+### Storage
+
+| Feature | Module | Default |
+|---------|--------|---------|
+| ZFS Support | `tuinix.zfs` | Enabled (x86_64) |
+| ZFS Encryption | `tuinix.zfs.encryption` | Enabled |
+
+### Security
+
+| Feature | Module | Default |
+|---------|--------|---------|
+| SSH Server | `tuinix.security.ssh` | Disabled |
+| Firewall | `tuinix.security.firewall` | Disabled |
+
+### System
+
+| Feature | Module | Default |
+|---------|--------|---------|
+| Cross-arch Emulation | `tuinix.emulation` | Disabled |
+
+## Default Packages
+
+### Live ISO Environment
+
+The installation ISO includes these packages:
+
+```
+Core Tools:
+- vim, nano (editors)
+- git (version control)
+- curl, wget (network utilities)
+
+Disk Management:
+- parted, gptfdisk (partitioning)
+- e2fsprogs, dosfstools, xfsprogs (filesystems)
+- zfs (ZFS tools, x86_64 only)
+- disko (declarative disk management)
+
+Installation:
+- nixos-install-tools
+- mkpasswd (password hashing)
+
+TUI:
+- gum (interactive prompts)
+- catimg (image display)
+- tuinix-installer (custom TUI installer)
+
+iPhone Tethering:
+- libimobiledevice
+- ifuse
+- usbmuxd
+```
+
+### Installed System
+
+Systems installed via the tuinix installer include:
+
+```
+Core Tools:
+- vim (editor)
+- git (version control)
+- curl, wget (network utilities)
+- htop (process viewer)
+- tree (directory listing)
+
+Networking:
+- networkmanager (nmtui, nmcli)
+- libimobiledevice, ifuse, usbmuxd (iPhone tethering)
+
+Home Manager:
+- Git configuration (user name, email)
+- Default shell configuration
+```
+
+## Storage Modes
+
+### Single Disk Options
+
+| Mode | Filesystem | Encryption | Features |
+|------|------------|------------|----------|
+| Encrypted ZFS | ZFS | AES-256-GCM | Compression, snapshots, checksums |
+| XFS Unencrypted | XFS | None | Maximum performance, latest kernel |
+
+### Multi-Disk Options (ZFS)
+
+| Mode | Redundancy | Min Disks | Fault Tolerance |
+|------|------------|-----------|-----------------|
+| Stripe | None | 2 | 0 disks |
+| RAIDZ | Single parity | 3 | 1 disk |
+| RAIDZ2 | Double parity | 4 | 2 disks |
+
+### ZFS Dataset Layout
+
+```
+NIXROOT/
+├── root      (/)           - Root filesystem
+├── nix       (/nix)        - Nix store (5% of disk, min 20GB)
+├── home      (/home)       - User data
+├── overflow  (/overflow)   - Extra storage
+└── atuin     (/var/atuin)  - Shell history (XFS zvol)
+```
+
+## Boot Requirements
+
+| Requirement | Value |
+|-------------|-------|
+| Boot Mode | UEFI only |
+| Secure Boot | Must be disabled (unsigned ZFS modules) |
+| Boot Partition | 5GB FAT32 EFI System Partition |
+
+## Hardware Requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU | x86_64 or aarch64 | Modern multi-core |
+| RAM | 4 GB | 8 GB+ |
+| Storage | 20 GB | 50 GB+ SSD |
+| Boot Mode | UEFI | UEFI |
+
+## ISO Build System
+
+### Build Command
+
+```bash
+./scripts/build-iso.sh [architecture]
+```
+
+| Argument | Description |
+|----------|-------------|
+| (none) | Build x86_64 ISO (default) |
+| `x86_64` | Build x86_64 ISO |
+| `aarch64` | Build aarch64 ISO |
+| `both` | Build both architectures |
+
+### Output
+
+ISOs are placed in the project root:
+- `tuinix.VERSION.x86_64.iso`
+- `tuinix.VERSION.aarch64.iso`
+
+### Build Requirements
+
+- Nix with flakes enabled
+- `gum` package (provided by dev shell)
+- ~10GB disk space for x86_64 build
+- ~8GB disk space for aarch64 build
+- For aarch64 on x86_64: QEMU binfmt emulation enabled
+
+## Flake Structure
+
+```
+tuinix/
+├── flake.nix              # Main flake definition
+├── flake.lock             # Locked dependencies
+├── installer.nix          # ISO installer configuration
+├── modules/               # NixOS modules
+│   ├── system/            # Boot, nix settings, ZFS, emulation
+│   ├── networking/        # NetworkManager, WiFi, iPhone tethering
+│   └── security/          # SSH, firewall
+├── hosts/                 # Host configurations
+│   ├── laptop/            # Example laptop host
+│   └── r36s/              # R36S handheld (planned)
+├── users/                 # User configurations
+├── profiles/              # System profiles (VM, workstation)
+├── templates/             # Disko templates
+├── scripts/               # Build and utility scripts
+└── docs/                  # MkDocs documentation
+```
+
+## NixOS Configurations
+
+| Configuration | Description |
+|---------------|-------------|
+| `laptop` | Example laptop with ZFS, NetworkManager |
+| `r36s` | R36S handheld (aarch64, no ZFS) |
+| `installer` | x86_64 installation ISO |
+| `installer-aarch64` | aarch64 installation ISO |
+
+## Module Options
+
+### tuinix.networking.networkmanager
+
+```nix
+tuinix.networking.networkmanager = {
+  enable = true;  # Enable NetworkManager (provides nmtui)
+};
+```
+
+### tuinix.networking.iphone-tethering
+
+```nix
+tuinix.networking.iphone-tethering = {
+  enable = true;  # Enable iPhone USB tethering support
+};
+```
+
+### tuinix.zfs
+
+```nix
+tuinix.zfs = {
+  enable = true;       # Enable ZFS support
+  encryption = true;   # Request encryption credentials at boot
+};
+```
+
+### tuinix.security.ssh
+
+```nix
+tuinix.security.ssh = {
+  enable = true;  # Enable OpenSSH server
+};
+```
+
+### tuinix.security.firewall
+
+```nix
+tuinix.security.firewall = {
+  enable = true;  # Enable firewall with SSH port open
+};
+```
+
+### tuinix.emulation
+
+```nix
+tuinix.emulation = {
+  enable = true;    # Enable cross-architecture emulation
+  aarch64 = true;   # Specifically enable aarch64 emulation
+};
+```
+
+## Installer Workflow
+
+1. **Network Check** - Verify connectivity (can be skipped for offline)
+2. **User Setup** - Username, full name, email, password
+3. **System Setup** - Hostname, storage mode, disk selection
+4. **Encryption** - ZFS passphrase (if applicable)
+5. **Locale** - Language, keyboard layout
+6. **SSH** - Optional SSH server with GitHub key import
+7. **Confirmation** - Review and type `DESTROY` to proceed
+8. **Installation** - Disko partitioning, nixos-install, flake copy
+
+## Post-Installation
+
+### File Locations
+
+| Path | Description |
+|------|-------------|
+| `/etc/tuinix` | System reference copy of flake |
+| `~/tuinix` | User's working copy (git repo) |
+| `~/tuinix-install.log` | Installation log |
+
+### First Boot
+
+1. Remove USB drive
+2. Select tuinix from GRUB
+3. Enter ZFS encryption passphrase (if applicable)
+4. Log in with configured credentials
+
+### System Updates
+
+```bash
+cd ~/tuinix
+git pull                                    # Get upstream changes
+sudo nixos-rebuild switch --flake .#hostname
+```
+
+## Version Information
+
+- **NixOS Base**: nixos-unstable
+- **Nix Features**: flakes, nix-command
+- **State Version**: 25.11
+
+## Dependencies
+
+### Flake Inputs
+
+| Input | Description |
+|-------|-------------|
+| nixpkgs | NixOS packages (nixos-unstable) |
+| nixos-hardware | Hardware-specific configurations |
+| disko | Declarative disk partitioning |
+| home-manager | User environment management |
+| flake-utils | Flake helper utilities |
+
+## License
+
+tuinix is open source software. See the repository for license details.

--- a/build-info.txt
+++ b/build-info.txt
@@ -1,6 +1,6 @@
 tuinix Build Information
 ==============================
-Version: v0.5.0
-Build Date: 2026-02-08 20:32:36 UTC
-Commit: 55f7bfb (main)
+Version: v0.5.0-13-g442aa3c
+Build Date: 2026-02-13 13:25:54 UTC
+Commit: 442aa3c (feature/multi-arch-iso)
 Builder: timlinux@abyss-laptop

--- a/build-info.txt
+++ b/build-info.txt
@@ -1,6 +1,6 @@
 tuinix Build Information
 ==============================
-Version: v0.5.0-13-g442aa3c
-Build Date: 2026-02-13 13:25:54 UTC
-Commit: 442aa3c (feature/multi-arch-iso)
+Version: v0.5.0-17-g5ec70ed
+Build Date: 2026-02-13 15:17:48 UTC
+Commit: 5ec70ed (feature/multi-arch-iso)
 Builder: timlinux@abyss-laptop

--- a/cmd/installer/install.go
+++ b/cmd/installer/install.go
@@ -232,11 +232,18 @@ func generateHostConfig(c Config) error {
   environment.systemPackages = with pkgs; [
     vim
     git
+    curl
+    wget
+    htop
+    tree
   ];
 
 %s
 %s
   boot.consoleLogLevel = 3;
+
+  # Enable NetworkManager for network management (provides nmtui)
+  tuinix.networking.networkmanager.enable = true;
 
   # Enable iPhone USB tethering support
   tuinix.networking.iphone-tethering.enable = true;

--- a/docs/installation/bare-metal.md
+++ b/docs/installation/bare-metal.md
@@ -2,11 +2,18 @@
 
 This guide covers installing tuinix on a real physical machine.
 
+## Supported Architectures
+
+| Architecture | ISO | Target Devices |
+|--------------|-----|----------------|
+| x86_64 | `tuinix.VERSION.x86_64.iso` | Standard PCs, laptops, servers |
+| aarch64 | `tuinix.VERSION.aarch64.iso` | ARM64 devices with UEFI boot |
+
 ## Hardware Requirements
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| CPU | x86_64 | Modern x86_64 (AMD Ryzen / Intel Core) |
+| CPU | x86_64 or aarch64 | Modern multi-core (AMD Ryzen / Intel Core / ARM64) |
 | RAM | 4 GB | 8 GB+ |
 | Storage | 20 GB | 50 GB+ (SSD strongly recommended) |
 | Boot mode | UEFI | UEFI |
@@ -25,11 +32,22 @@ or build it yourself:
 ```bash
 git clone https://github.com/timlinux/tuinix.git
 cd tuinix
+
+# Build for x86_64 (default)
 ./scripts/build-iso.sh
+
+# Build for aarch64 (ARM64)
+./scripts/build-iso.sh aarch64
+
+# Build both architectures
+./scripts/build-iso.sh both
 ```
 
-The ISO includes the installer and system configuration. An internet
-connection is required during installation to fetch packages.
+!!! success "Fully Offline Installation"
+    The tuinix ISO includes the complete system closure - all packages
+    required for installation are pre-cached. No internet connection is
+    needed for standard configurations. This is ideal for air-gapped
+    environments or locations with poor connectivity.
 
 ## Step 2: Flash the ISO to a USB drive
 
@@ -71,10 +89,14 @@ Before booting from USB, enter your BIOS/UEFI settings (typically by pressing F2
 !!! tip
     Many machines have a one-time boot menu (often F12) that lets you select the USB without changing permanent settings.
 
-## Network connectivity
+## Network connectivity (optional)
 
-The installer requires an internet connection to download packages. Here are several options for
-getting online from the live environment:
+Since the tuinix ISO includes all packages for offline installation, network
+connectivity is **optional** for standard configurations. However, if your
+configuration adds packages beyond the standard set, or you want to pull
+the latest updates, an internet connection may be useful.
+
+Here are several options for getting online from the live environment:
 
 ### Ethernet (automatic)
 
@@ -116,8 +138,8 @@ sudo installer
 
 The interactive TUI installer will guide you through:
 
-1. **Network check** -- the installer verifies internet connectivity (required for fetching packages).
-   If no connection is detected, you'll be prompted to configure networking and retry.
+1. **Network check** -- the installer checks internet connectivity. This can be skipped for
+   offline installations since all packages are pre-cached on the ISO.
 2. **Username** -- enter your login username
 3. **Full name** -- your display name (used in git config)
 4. **Email** -- your email address (used in git config)
@@ -248,6 +270,28 @@ The pool mode determines redundancy:
 
 ZFS datasets are the same as the single-disk encrypted ZFS layout.
 
+## Default Packages
+
+Every tuinix installation includes these packages out of the box:
+
+**Networking:**
+
+- NetworkManager with `nmtui` for easy WiFi/network configuration
+- iPhone USB tethering support (libimobiledevice, usbmuxd, ifuse)
+
+**Core Tools:**
+
+- vim, git, curl, wget, htop, tree
+
+**ZFS Features (x86_64 only):**
+
+- Full ZFS support with encryption, compression, and snapshots
+- Native ZFS kernel modules
+
+!!! note "Architecture Differences"
+    ZFS is only available on x86_64 installations. On aarch64, the XFS
+    storage mode is used instead for maximum compatibility.
+
 ## Post-installation
 
 After installation, the flake is copied to two locations:
@@ -333,3 +377,9 @@ If your system won't boot:
 | "no such pool available" | Disk has no `/dev/disk/by-id/` entry | Rare on real hardware; check disk WWN with `ls -la /dev/disk/by-id/` |
 | Installation fails | Not enough disk space | Need at least 20 GB free |
 | Can't type passphrase | Wrong keyboard layout in initrd | Reinstall with correct keyboard layout |
+| "path not found" during offline install | Custom packages not in ISO closure | Connect to internet or rebuild ISO with custom packages |
+
+!!! tip "Offline Installation Notes"
+    The ISO includes all standard tuinix packages. If you modify the
+    configuration to add packages not in the standard set, you may need
+    an internet connection or to rebuild the ISO with your custom closure.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,8 +1,31 @@
 # Installation Overview
 
-tuinix ships as an ISO image that includes the installer and system
-configuration. An internet connection is required during installation
-to fetch packages.
+tuinix ships as an ISO image that includes the installer, system configuration,
+and all packages needed for a complete offline installation.
+
+## Supported Architectures
+
+| Architecture | ISO | Target Devices |
+|--------------|-----|----------------|
+| x86_64 | `tuinix.VERSION.x86_64.iso` | Standard PCs, laptops, servers |
+| aarch64 | `tuinix.VERSION.aarch64.iso` | ARM64 devices with UEFI boot |
+
+## Installation Modes
+
+### Offline Installation (Default)
+
+The ISO includes the complete system closure - all packages required for
+installation are pre-cached. No internet connection needed for standard
+configurations.
+
+!!! success "Fully Offline"
+    The tuinix ISO can install a complete system without any network access.
+    This is ideal for air-gapped environments or locations with poor connectivity.
+
+### Online Installation
+
+If your configuration adds packages beyond the standard set, an internet
+connection may be required to fetch additional packages.
 
 ## Get the ISO
 
@@ -13,7 +36,15 @@ or build it yourself:
 ```bash
 git clone https://github.com/timlinux/tuinix.git
 cd tuinix
+
+# Build for x86_64 (default)
 ./scripts/build-iso.sh
+
+# Build for aarch64 (ARM64)
+./scripts/build-iso.sh aarch64
+
+# Build both architectures
+./scripts/build-iso.sh both
 ```
 
 ## Choose your target
@@ -27,12 +58,31 @@ cd tuinix
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| CPU | x86_64 | Modern x86_64 |
+| CPU | x86_64 or aarch64 | Modern multi-core |
 | RAM | 4 GB | 8 GB+ |
-| Storage | 20 GB | 50 GB+ |
+| Storage | 20 GB | 50 GB+ SSD |
 | Boot mode | UEFI | UEFI |
 
 !!! warning "UEFI required"
     tuinix requires UEFI boot mode. Legacy BIOS is not supported.
     Secure Boot must be disabled because ZFS kernel modules are
     unsigned.
+
+## Default Packages
+
+Every tuinix installation includes:
+
+**Networking:**
+
+- NetworkManager with `nmtui` for easy WiFi/network configuration
+- iPhone USB tethering support (libimobiledevice, usbmuxd)
+
+**Core Tools:**
+
+- vim, git, curl, wget, htop, tree
+
+**ZFS Features (x86_64):**
+
+- Full ZFS support with encryption, compression, and snapshots
+
+See the [Specification](../SPECIFICATION.md) for complete package lists.

--- a/docs/r36s-build-notes.md
+++ b/docs/r36s-build-notes.md
@@ -1,0 +1,192 @@
+# R36S NixOS Build Notes
+
+This document captures the research and context needed to create a direct-flash SD card image for the R36S handheld gaming device.
+
+## Device Overview
+
+- **Device**: R36S handheld gaming console
+- **SoC**: Rockchip RK3326 (ARM Cortex-A35 quad-core)
+- **Architecture**: aarch64 (ARM64)
+- **Storage**: SD card slots (TF1 and TF2)
+- **Display**: 3.5" IPS screen (multiple panel variants exist)
+
+## Why ISO Won't Work
+
+The standard aarch64 ISO requires UEFI boot support. The R36S uses Rockchip's custom boot flow:
+
+1. **BootROM** (on-chip) looks for bootloader at specific SD card offsets
+2. **idbloader.img** must be at sector 64 (0x40)
+3. **u-boot.itb** must be at sector 16384 (0x4000)
+4. No UEFI - uses U-Boot with extlinux.conf
+
+## Required Components
+
+### 1. U-Boot Bootloader
+
+Need R36S-specific U-Boot binaries:
+- `idbloader.img` - First stage loader (DDR init + SPL)
+- `u-boot.itb` - Main U-Boot binary
+
+**Sources:**
+- [R36S-Stuff/R36S-u-boot](https://github.com/R36S-Stuff/R36S-u-boot)
+- [AndreRenaud/u-boot-r36s](https://github.com/AndreRenaud/u-boot-r36s)
+- Extract from stock R36S SD card image
+
+### 2. Device Tree Blob (DTB)
+
+**Critical**: R36S has 5+ display panel variants. Wrong DTB = black screen.
+
+Common DTB names:
+- `rk3326-r36s.dtb`
+- `rk3326-r35s-linux.dtb`
+- `rk3326-rg351mp-linux.dtb`
+- `gameconsole-r36s.dtb`
+
+Best approach: Extract from stock image to match your specific hardware revision.
+
+### 3. Kernel
+
+Options:
+- Mainline Linux with RK3326 support (may need patches)
+- Vendor kernel from R36S firmware
+- Community kernel (JELOS, ArkOS sources)
+
+## SD Card Layout
+
+```
+Offset (sectors)  | Content
+------------------|------------------
+0-63              | Reserved (MBR at 0)
+64                | idbloader.img (~200KB)
+16384             | u-boot.itb (~1MB)
+32768             | Boot partition (FAT32) - kernel, DTB, extlinux.conf
+262144+           | Root partition (ext4) - NixOS root filesystem
+```
+
+## Implementation Plan
+
+### Step 1: Extract Stock Image Components
+
+```bash
+# Dump the bootloader region
+sudo dd if=/dev/sdX of=r36s-bootloader.bin bs=512 count=32768
+
+# Mount and copy boot partition contents
+sudo mount /dev/sdX1 /mnt
+cp -r /mnt/* ./r36s-boot-contents/
+
+# Find and copy the DTB
+find ./r36s-boot-contents -name "*.dtb" -exec cp {} ./r36s.dtb \;
+```
+
+### Step 2: Create NixOS SD Image Module
+
+```nix
+# modules/images/r36s-sd-image.nix
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    "${pkgs.path}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  # Use extlinux bootloader (not GRUB)
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  # R36S device tree
+  hardware.deviceTree.enable = true;
+  hardware.deviceTree.name = "rockchip/rk3326-r36s.dtb";
+
+  # Serial console for debugging
+  boot.kernelParams = [
+    "console=ttyS2,1500000n8"
+    "root=/dev/mmcblk0p2"
+    "rootwait"
+  ];
+
+  # SD image settings
+  sdImage = {
+    compressImage = false;
+    imageBaseName = "tuinix-r36s";
+
+    # Write U-Boot to correct offsets
+    postBuildCommands = ''
+      # Write idbloader at sector 64
+      dd if=${./firmware/idbloader.img} of=$img bs=512 seek=64 conv=notrunc
+
+      # Write u-boot.itb at sector 16384
+      dd if=${./firmware/u-boot.itb} of=$img bs=512 seek=16384 conv=notrunc
+    '';
+  };
+}
+```
+
+### Step 3: Add to Flake
+
+```nix
+# In flake.nix
+nixosConfigurations.r36s-sd = nixpkgs.lib.nixosSystem {
+  system = "aarch64-linux";
+  modules = [
+    ./modules/images/r36s-sd-image.nix
+    ./hosts/r36s
+  ];
+};
+
+# Build with:
+# nix build .#nixosConfigurations.r36s-sd.config.system.build.sdImage
+```
+
+### Step 4: Build Script
+
+Add to `scripts/build-iso.sh` or create `scripts/build-sd-image.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Build R36S SD card image
+
+nix build .#nixosConfigurations.r36s-sd.config.system.build.sdImage
+
+# Copy to project root
+cp result/sd-image/*.img ./tuinix.${VERSION}.r36s.img
+```
+
+## Files to Create
+
+1. `modules/images/r36s-sd-image.nix` - SD image configuration
+2. `firmware/r36s/idbloader.img` - Extracted/built U-Boot stage 1
+3. `firmware/r36s/u-boot.itb` - Extracted/built U-Boot stage 2
+4. `firmware/r36s/rk3326-r36s.dtb` - Device tree for your R36S variant
+5. `scripts/build-sd-image.sh` - Build script for SD images
+
+## Reference Projects
+
+- [nabam/nixos-rockchip](https://github.com/nabam/nixos-rockchip) - NixOS on Rockchip boards
+- [Mic92/nixos-aarch64-images](https://github.com/Mic92/nixos-aarch64-images) - ARM64 image patterns
+- [JELOS](https://github.com/JustEnoughLinuxOS/distribution) - R36S-compatible Linux distro
+- [ArkOS](https://github.com/christianhaitian/arkos) - Another R36S Linux option
+
+## Debugging
+
+### Serial Console
+
+R36S uses UART2 at 1500000 baud:
+```
+console=ttyS2,1500000n8
+```
+
+### Common Issues
+
+1. **Black screen**: Wrong DTB for your display panel variant
+2. **No boot**: idbloader/u-boot at wrong offset or corrupted
+3. **Kernel panic**: Missing drivers or wrong root= parameter
+4. **No SD card detected**: Need correct MMC driver in kernel
+
+## User Action Required
+
+Before implementing, provide:
+1. **Stock SD card image** or mounted device path for extraction
+2. **R36S variant info** (check sticker on device or boot screen)
+
+This will let us extract the exact bootloader and DTB for your specific unit.

--- a/flake.nix
+++ b/flake.nix
@@ -178,14 +178,27 @@
 
         # ISO configurations for installation
         {
+          # x86_64 installer
           "installer" = nixpkgs.lib.nixosSystem {
-            inherit system;
+            system = "x86_64-linux";
             specialArgs = {
               inherit inputs;
               hostname = "nixos";
               inherit (nixpkgs) lib;
             };
-            modules = [ ./installer.nix ];
+            modules = [ (import ./installer.nix { system = "x86_64-linux"; }) ];
+          };
+
+          # aarch64 installer (for R36S and ARM devices)
+          "installer-aarch64" = nixpkgs.lib.nixosSystem {
+            system = "aarch64-linux";
+            specialArgs = {
+              inherit inputs;
+              hostname = "nixos";
+              inherit (nixpkgs) lib;
+            };
+            modules =
+              [ (import ./installer.nix { system = "aarch64-linux"; }) ];
           };
         };
 

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -8,6 +8,9 @@
   # On a real install, generate with: head -c 8 /etc/machine-id
   networking.hostId = "a1b2c3d4";
 
+  # Enable NetworkManager for network management (provides nmtui)
+  tuinix.networking.networkmanager.enable = true;
+
   # Enable iPhone USB tethering support
   tuinix.networking.iphone-tethering.enable = true;
 

--- a/installer.nix
+++ b/installer.nix
@@ -32,6 +32,44 @@ let
 in {
   imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix") ];
 
+  # Include system build dependencies for offline installation
+  # This adds packages needed for a basic tuinix installation without network
+  isoImage.storeContents = with pkgs; [
+    # Core system packages that will be installed
+    networkmanager
+    vim
+    git
+    curl
+    wget
+    htop
+    tree
+    # iPhone tethering
+    libimobiledevice
+    ifuse
+    usbmuxd
+    # Boot and filesystem tools
+    grub2
+    efibootmgr
+    # Kernel and firmware - essential for any install
+    linuxPackages.kernel
+    linux-firmware
+    # System utilities
+    systemd
+    dbus
+    pam
+    shadow
+    util-linux
+    coreutils
+    bash
+    # Nix itself for the installed system
+    nix
+    # Home-manager for user configuration
+    home-manager
+  ];
+
+  # Include build dependencies so offline rebuilds work better
+  system.includeBuildDependencies = true;
+
   # Include flake files and assets on the ISO
   isoImage.contents = [
     {

--- a/installer.nix
+++ b/installer.nix
@@ -1,4 +1,6 @@
 # tuinix installer ISO configuration
+# This is a curried module: first call with { system } to get the actual module
+{ system ? "x86_64-linux" }:
 { config, lib, pkgs, modulesPath, ... }:
 
 let
@@ -71,31 +73,33 @@ in {
   ];
 
   # Packages for installation environment - minimal set, no X11/GUI deps
-  environment.systemPackages = with pkgs; [
-    tuinix-installer
-    git
-    vim
-    nano
-    curl
-    wget
-    parted
-    gptfdisk
-    e2fsprogs
-    dosfstools
-    xfsprogs
-    zfs
-    disko
-    gum
-    catimg
-    bc
-    nixos-install-tools
-    mkpasswd
-    util-linux
-    # iPhone USB tethering support
-    libimobiledevice
-    ifuse
-    usbmuxd
-  ];
+  environment.systemPackages = with pkgs;
+    [
+      tuinix-installer
+      git
+      vim
+      nano
+      curl
+      wget
+      parted
+      gptfdisk
+      e2fsprogs
+      dosfstools
+      xfsprogs
+      disko
+      gum
+      catimg
+      bc
+      nixos-install-tools
+      mkpasswd
+      util-linux
+      # iPhone USB tethering support
+      libimobiledevice
+      ifuse
+      usbmuxd
+    ]
+    # ZFS only available on x86_64
+    ++ lib.optionals (system == "x86_64-linux") [ zfs ];
 
   # Enable SSH
   services.openssh.enable = true;

--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -2,5 +2,10 @@
 { lib, ... }:
 
 {
-  imports = [ ./wireless.nix ./ethernet.nix ./iphone-tethering.nix ];
+  imports = [
+    ./wireless.nix
+    ./ethernet.nix
+    ./iphone-tethering.nix
+    ./networkmanager.nix
+  ];
 }

--- a/modules/networking/networkmanager.nix
+++ b/modules/networking/networkmanager.nix
@@ -1,0 +1,30 @@
+# NetworkManager configuration with nmtui
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.tuinix.networking.networkmanager = {
+    enable = mkEnableOption "Enable NetworkManager for network management";
+  };
+
+  config = mkIf config.tuinix.networking.networkmanager.enable {
+    # Enable NetworkManager
+    networking.networkmanager = {
+      enable = true;
+      wifi.powersave = true;
+    };
+
+    # Disable conflicting network services
+    networking.useDHCP = lib.mkDefault false;
+
+    # NetworkManager tools including nmtui
+    environment.systemPackages = with pkgs; [
+      networkmanager # includes nmtui, nmcli
+      networkmanagerapplet # nm-applet for tray (optional)
+    ];
+
+    # Add users to networkmanager group
+    users.groups.networkmanager = { };
+  };
+}

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build bootable ISO for tuinix laptop profile
+# Build bootable ISO for tuinix - supports x86_64 and aarch64 architectures
 
 set -euo pipefail
 
@@ -8,6 +8,22 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Version for ISO naming - defaults to latest git tag or 'dev'
 VERSION="${TUINIX_VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")}"
+
+# Architecture selection - defaults to x86_64
+ARCH="${1:-x86_64}"
+
+# Validate architecture argument
+case "$ARCH" in
+  x86_64|aarch64|both)
+    ;;
+  *)
+    echo "Usage: $0 [x86_64|aarch64|both]"
+    echo "  x86_64  - Build ISO for x86_64 (default)"
+    echo "  aarch64 - Build ISO for aarch64 (R36S, ARM devices)"
+    echo "  both    - Build ISOs for both architectures"
+    exit 1
+    ;;
+esac
 
 # Check if gum is available
 if ! command -v gum >/dev/null 2>&1; then
@@ -25,7 +41,8 @@ gum style \
   "" \
   "Building bootable ISO with embedded flake" \
   "Working directory: $PROJECT_ROOT" \
-  "Version: $VERSION"
+  "Version: $VERSION" \
+  "Architecture: $ARCH"
 
 cd "$PROJECT_ROOT"
 
@@ -152,98 +169,139 @@ else
   exit 1
 fi
 
-# Build the ISO
-gum style \
-  --foreground="#e95420" \
-  --border="rounded" \
-  --padding="1" \
-  "🏗️  tuinix ISO Build" \
-  "" \
-  "Starting comprehensive build process..." \
-  "This may take 10-30 minutes depending on your system"
+# Function to build ISO for a specific architecture
+build_iso_for_arch() {
+  local arch="$1"
+  local installer_name
 
-echo ""
-
-# Use gum's simple and reliable spinner
-if ! gum spin --spinner="dot" --title="Building ISO image (this may take a while)..." --show-output -- nix build .#nixosConfigurations.installer.config.system.build.isoImage; then
-  echo ""
-  gum style --foreground="#ff0000" --border="rounded" --padding="1" "❌ ISO build failed!" "Check the output above for error details."
-  exit 1
-fi
-
-echo ""
-gum style --foreground="#00cc00" "🎉 ISO build completed successfully!"
-
-# Check if build was successful
-if [[ -L "result" && -d "result/iso" ]]; then
-  # Find ISO file (either .iso or .iso.zst)
-  ISO_PATH=$(find result/iso -name "*.iso" -o -name "*.iso.zst" | head -1)
-  ISO_NAME=$(basename "$ISO_PATH")
-
-  gum style \
-    --foreground="#00cc00" \
-    --border="rounded" \
-    --padding="1" \
-    "✅ ISO built successfully!" \
-    "" \
-    "📀 ISO location: $ISO_PATH" \
-    "📁 ISO name: $ISO_NAME"
-
-  # Determine final ISO name
-  FINAL_ISO_NAME="tuinix.${VERSION}.iso"
-  if [[ -f "./$FINAL_ISO_NAME" ]]; then
-    gum style --foreground="#ffaa00" "⚠️  Removing existing ISO: ./$FINAL_ISO_NAME"
-    sudo rm "./$FINAL_ISO_NAME"
-  fi
-
-  if [[ "$ISO_PATH" == *.zst ]]; then
-    gum style --foreground="#0066cc" "📦 Decompressing ISO..."
-    TEMP_ISO_NAME="${ISO_NAME%.zst}"
-    gum spin --spinner="dot" --title="Decompressing..." -- zstd -d "$ISO_PATH" -o "./$TEMP_ISO_NAME"
-
-    # Validate the decompressed ISO
-    if validate_iso "./$TEMP_ISO_NAME"; then
-      # Rename to final name
-      mv "./$TEMP_ISO_NAME" "./$FINAL_ISO_NAME"
-      gum style --foreground="#00cc00" "✅ ISO created and validated: ./$FINAL_ISO_NAME"
-    else
-      gum style --foreground="#ff0000" "❌ ISO validation failed - removing invalid ISO"
-      rm -f "./$TEMP_ISO_NAME"
-      exit 1
-    fi
+  # Determine the installer configuration name
+  if [[ "$arch" == "x86_64" ]]; then
+    installer_name="installer"
   else
-    gum style --foreground="#0066cc" "📋 Copying ISO..."
-    gum spin --spinner="dot" --title="Copying..." -- cp "$ISO_PATH" "./$FINAL_ISO_NAME"
-
-    # Validate the copied ISO
-    if validate_iso "./$FINAL_ISO_NAME"; then
-      gum style --foreground="#00cc00" "✅ ISO created and validated: ./$FINAL_ISO_NAME"
-    else
-      gum style --foreground="#ff0000" "❌ ISO validation failed - removing invalid ISO"
-      rm -f "./$FINAL_ISO_NAME"
-      exit 1
-    fi
+    installer_name="installer-${arch}"
   fi
-
-  # Show final information
-  ISO_SIZE=$(du -h "./$FINAL_ISO_NAME" | cut -f1)
 
   gum style \
     --foreground="#e95420" \
     --border="rounded" \
     --padding="1" \
+    "🏗️  tuinix ISO Build ($arch)" \
+    "" \
+    "Starting build process for $arch..." \
+    "This may take 10-30 minutes depending on your system"
+
+  echo ""
+
+  # Use gum's simple and reliable spinner
+  if ! gum spin --spinner="dot" --title="Building $arch ISO image (this may take a while)..." --show-output -- nix build ".#nixosConfigurations.${installer_name}.config.system.build.isoImage"; then
+    echo ""
+    gum style --foreground="#ff0000" --border="rounded" --padding="1" "❌ ISO build failed for $arch!" "Check the output above for error details."
+    return 1
+  fi
+
+  echo ""
+  gum style --foreground="#00cc00" "🎉 ISO build completed successfully for $arch!"
+
+  # Check if build was successful
+  if [[ -L "result" && -d "result/iso" ]]; then
+    # Find ISO file (either .iso or .iso.zst)
+    ISO_PATH=$(find result/iso -name "*.iso" -o -name "*.iso.zst" | head -1)
+    ISO_NAME=$(basename "$ISO_PATH")
+
+    gum style \
+      --foreground="#00cc00" \
+      --border="rounded" \
+      --padding="1" \
+      "✅ ISO built successfully!" \
+      "" \
+      "📀 ISO location: $ISO_PATH" \
+      "📁 ISO name: $ISO_NAME"
+
+    # Determine final ISO name (include arch in name)
+    FINAL_ISO_NAME="tuinix.${VERSION}.${arch}.iso"
+    if [[ -f "./$FINAL_ISO_NAME" ]]; then
+      gum style --foreground="#ffaa00" "⚠️  Removing existing ISO: ./$FINAL_ISO_NAME"
+      sudo rm "./$FINAL_ISO_NAME"
+    fi
+
+    if [[ "$ISO_PATH" == *.zst ]]; then
+      gum style --foreground="#0066cc" "📦 Decompressing ISO..."
+      TEMP_ISO_NAME="${ISO_NAME%.zst}"
+      gum spin --spinner="dot" --title="Decompressing..." -- zstd -d "$ISO_PATH" -o "./$TEMP_ISO_NAME"
+
+      # Validate the decompressed ISO
+      if validate_iso "./$TEMP_ISO_NAME"; then
+        # Rename to final name
+        mv "./$TEMP_ISO_NAME" "./$FINAL_ISO_NAME"
+        gum style --foreground="#00cc00" "✅ ISO created and validated: ./$FINAL_ISO_NAME"
+      else
+        gum style --foreground="#ff0000" "❌ ISO validation failed - removing invalid ISO"
+        rm -f "./$TEMP_ISO_NAME"
+        return 1
+      fi
+    else
+      gum style --foreground="#0066cc" "📋 Copying ISO..."
+      gum spin --spinner="dot" --title="Copying..." -- cp "$ISO_PATH" "./$FINAL_ISO_NAME"
+
+      # Validate the copied ISO
+      if validate_iso "./$FINAL_ISO_NAME"; then
+        gum style --foreground="#00cc00" "✅ ISO created and validated: ./$FINAL_ISO_NAME"
+      else
+        gum style --foreground="#ff0000" "❌ ISO validation failed - removing invalid ISO"
+        rm -f "./$FINAL_ISO_NAME"
+        return 1
+      fi
+    fi
+
+    # Show final information
+    ISO_SIZE=$(du -h "./$FINAL_ISO_NAME" | cut -f1)
+
+    gum style \
+      --foreground="#e95420" \
+      --border="rounded" \
+      --padding="1" \
+      --margin="1" \
+      "🎉 ISO Build Complete ($arch)!" \
+      "" \
+      "📊 ISO Information:" \
+      "  📁 Name: $FINAL_ISO_NAME" \
+      "  📏 Size: $ISO_SIZE" \
+      "  🏷️  Version: $VERSION" \
+      "" \
+      "💾 To create a bootable USB:" \
+      "  sudo dd if=./$FINAL_ISO_NAME of=/dev/sdX bs=4M status=progress" \
+      "  (Replace /dev/sdX with your USB device)"
+
+    # Clean up result symlink for next build
+    rm -f result
+
+    return 0
+  else
+    gum style --foreground="#ff0000" "❌ ISO build failed or result not found for $arch"
+    return 1
+  fi
+}
+
+# Build ISOs based on architecture selection
+if [[ "$ARCH" == "both" ]]; then
+  gum style --foreground="#0066cc" "📦 Building ISOs for both architectures..."
+  echo ""
+
+  build_iso_for_arch "x86_64" || exit 1
+  echo ""
+  build_iso_for_arch "aarch64" || exit 1
+
+  echo ""
+  gum style \
+    --foreground="#e95420" \
+    --border="rounded" \
+    --padding="1" \
     --margin="1" \
-    "🎉 ISO Build Complete!" \
+    "🎉 All ISO Builds Complete!" \
     "" \
-    "📊 ISO Information:" \
-    "  📁 Name: $FINAL_ISO_NAME" \
-    "  📏 Size: $ISO_SIZE" \
-    "  🏷️  Version: $VERSION" \
-    "" \
-    "💾 To create a bootable USB:" \
-    "  sudo dd if=./$FINAL_ISO_NAME of=/dev/sdX bs=4M status=progress" \
-    "  (Replace /dev/sdX with your USB device)"
+    "Built ISOs:" \
+    "  📀 tuinix.${VERSION}.x86_64.iso" \
+    "  📀 tuinix.${VERSION}.aarch64.iso"
 else
-  gum style --foreground="#ff0000" "❌ ISO build failed or result not found"
-  exit 1
+  build_iso_for_arch "$ARCH" || exit 1
 fi


### PR DESCRIPTION
## Summary
- Update build-iso.sh to accept architecture argument (x86_64, aarch64, or both)
- Add installer-aarch64 configuration to flake.nix
- Make installer.nix a curried module that accepts system parameter
- Make ZFS conditional (x86_64 only) since it's not suitable for aarch64/R36S
- Output ISOs to project root with architecture in filename (tuinix.VERSION.ARCH.iso)

## Usage
```bash
./scripts/build-iso.sh           # Build x86_64 (default)
./scripts/build-iso.sh x86_64    # Build x86_64
./scripts/build-iso.sh aarch64   # Build aarch64 (R36S)
./scripts/build-iso.sh both      # Build both architectures
```

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Build x86_64 ISO with `./scripts/build-iso.sh x86_64`
- [ ] Build aarch64 ISO with `./scripts/build-iso.sh aarch64`
- [ ] Verify ISOs are output to project root with correct naming