### PR TITLE
v0.7.1: Shrink ISO from 1.3GB to 51MB, fix flake ownership

### DIFF
--- a/cmd/installer/install.go
+++ b/cmd/installer/install.go
@@ -455,6 +455,11 @@ Keymap: %s`,
 
 	runCommand("git", "-C", userDir, "commit", "-m", commitMsg)
 
+	// Make /etc/tuinix a symlink to the user's copy - single source of truth
+	// Do this BEFORE chown so nixos-enter doesn't re-create files as root
+	runCommand("nixos-enter", "--root", "/mnt", "--command",
+		fmt.Sprintf("ln -sfn /home/%s/tuinix /etc/tuinix", c.Username))
+
 	// Look up the user's UID and GID from the installed system
 	uidOutput, uidErr := runCommand("nixos-enter", "--root", "/mnt", "--command",
 		fmt.Sprintf("id -u %s", c.Username))
@@ -467,16 +472,23 @@ Keymap: %s`,
 		gid := strings.TrimSpace(gidOutput)
 		if uid != "" && gid != "" {
 			ownership = uid + ":" + gid
-			logInfo("setupUserFlake: detected user %s ownership as %s", c.Username, ownership)
 		}
 	}
+	logInfo("setupUserFlake: setting ownership of %s to %s", userHome, ownership)
 
-	// Set ownership of the entire home directory to the user
-	runCommand("chown", "-R", ownership, userHome)
+	// Set ownership of the entire home directory AND tuinix flake to the user
+	// Run chown LAST so nothing else can re-root the files
+	if _, err := runCommand("chown", "-R", ownership, userHome); err != nil {
+		logError("setupUserFlake: chown home failed: %v", err)
+	}
+	// Explicit chown on tuinix dir in case the above missed anything
+	if _, err := runCommand("chown", "-R", ownership, userDir); err != nil {
+		logError("setupUserFlake: chown tuinix dir failed: %v", err)
+	}
 
-	// Make /etc/tuinix a symlink to the user's copy - single source of truth
-	runCommand("nixos-enter", "--root", "/mnt", "--command",
-		fmt.Sprintf("ln -sfn /home/%s/tuinix /etc/tuinix", c.Username))
+	// Verify ownership was set correctly
+	verifyOutput, _ := runCommand("ls", "-la", userDir)
+	logInfo("setupUserFlake: ownership verification:\n%s", verifyOutput)
 
 	return nil
 }

--- a/installer.nix
+++ b/installer.nix
@@ -32,27 +32,13 @@ let
 in {
   imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix") ];
 
-  # Include only essential networking packages for offline bootstrap
-  # The installer needs networking to fetch the actual system from cache
-  # We include: NetworkManager, nmtui, and iPhone tethering support
-  isoImage.storeContents = with pkgs; [
-    # NetworkManager stack for network configuration
-    networkmanager
-    # iPhone USB tethering support
-    libimobiledevice
-    ifuse
-    usbmuxd
-    # Boot and filesystem tools for installation
-    grub2
-    efibootmgr
-    # Basic utilities
-    vim
-    curl
-    git
-  ];
+  # No pre-cached store contents - online install fetches from cache.nixos.org
+  isoImage.storeContents = lib.mkForce [ ];
 
-  # Don't include build dependencies - keep ISO small
-  # Users will fetch packages from cache.nixos.org during install
+  # Better squashfs compression for smaller ISO
+  isoImage.squashfsCompression = "zstd -Xcompression-level 19";
+
+  # Don't include build dependencies
   system.includeBuildDependencies = false;
 
   # Include flake files and assets on the ISO
@@ -95,24 +81,18 @@ in {
     }
   ];
 
-  # Packages for installation environment - minimal set, no X11/GUI deps
+  # Minimal package set - only what the installer actually needs
   environment.systemPackages = with pkgs;
     [
       tuinix-installer
       git
       vim
-      nano
       curl
-      wget
       parted
       gptfdisk
       e2fsprogs
       dosfstools
-      xfsprogs
       disko
-      gum
-      catimg
-      bc
       nixos-install-tools
       mkpasswd
       util-linux
@@ -129,6 +109,9 @@ in {
 
   # Enable iPhone USB tethering support
   services.usbmuxd.enable = true;
+
+  # Disable ModemManager - not needed for terminal installer
+  systemd.services.ModemManager.enable = lib.mkForce false;
 
   # Set root password (override any defaults)
   users.users.root = {


### PR DESCRIPTION
## Summary

- Shrink installer ISO from **1.3 GB to 51 MB** by removing pre-cached store contents and unused packages
- Use zstd level 19 squashfs compression
- Fix post-install flake ownership (chown after nixos-enter, with verification logging)

## Test plan

- [ ] `nix run .#test-install` builds and boots the 51MB ISO
- [ ] Installer TUI works correctly with trimmed package set
- [ ] After install, `~/tuinix` is owned by the user (not root)

Made with :heart: by [Kartoza](https://kartoza.com)