### PR TITLE
Add XFS existing partition install mode for dual-boot support

### DIFF
--- a/claude.sh
+++ b/claude.sh
@@ -4,10 +4,21 @@ cd "$(dirname "$0")"
 exec > claude.out 2>&1
 
 git add -A
-git commit --no-verify -m "fix: add pull-requests write permission for PR comment, fix grep exit code
+git commit --no-verify -m "feat: add package set selection (TUI, Pentest, Games) and merge main
+
+- Package sets: three optional tiers as checkboxes in installer
+  - TUI: yazi, neovim, lazygit, btop, nchat, gomuks, scli, khal, starship, atuin
+  - Pentest: aircrack-ng, nmap, metasploit, wireshark, termshark, hashcat, sqlmap
+  - Games: angband, crawl, cataclysm-dda, vitetris, nudoku, frotz, bsdgames
+- Minimal base (vim, git, curl, htop, tmux) always installed
+- Merged main (PR #19) into this branch
+- Fixed locale conflict (import only en_US by default)
+- Fixed software/default.nix imports
+- Fixed modules/default.nix to include locale and software
+- Formatted all nix files
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 
 git push
 
-echo "Pushed permissions + grep fix."
+echo "Pushed to PR #20."

--- a/cmd/installer/disk.go
+++ b/cmd/installer/disk.go
@@ -41,6 +41,43 @@ func getAvailableDisks() []diskInfo {
 	return disks
 }
 
+func getAvailablePartitions(disk string) []partitionInfo {
+	var partitions []partitionInfo
+
+	cmd := exec.Command("lsblk", "-n", "-o", "NAME,SIZE,TYPE,FSTYPE,PARTLABEL", disk)
+	output, err := cmd.Output()
+	if err != nil {
+		return []partitionInfo{{Path: disk + "1", Size: "500M", FSType: "vfat", Label: "EFI System"}}
+	}
+
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[2] == "part" {
+			fsType := ""
+			if len(fields) >= 4 {
+				fsType = fields[3]
+			}
+			label := ""
+			if len(fields) >= 5 {
+				label = strings.Join(fields[4:], " ")
+			}
+			partitions = append(partitions, partitionInfo{
+				Path:   "/dev/" + fields[0],
+				Size:   fields[1],
+				FSType: fsType,
+				Label:  label,
+			})
+		}
+	}
+
+	if len(partitions) == 0 {
+		partitions = []partitionInfo{{Path: disk + "1", Size: "unknown", FSType: "", Label: "No partitions found"}}
+	}
+
+	return partitions
+}
+
 func calculateSpaceAllocation(c *Config) {
 	// For multi-disk ZFS, calculate total pool size across all disks
 	// (excluding the boot partition on the first disk)
@@ -71,6 +108,15 @@ func calculateSpaceAllocation(c *Config) {
 
 	bootGB := int64(5)
 	c.SpaceBoot = fmt.Sprintf("%dG", bootGB)
+
+	if c.StorageMode.usesPartitions() {
+		// Partition mode: using existing partitions, no space allocation needed
+		c.SpaceBoot = "(existing)"
+		c.SpaceNix = ""
+		c.SpaceAtuin = ""
+		c.SpaceHome = ""
+		return
+	}
 
 	if !c.StorageMode.isZFS() {
 		// XFS: just boot + root, no separate partitions
@@ -114,8 +160,42 @@ func getDiskSizeGB(disk string) int64 {
 	return sizeGB
 }
 
+func formatPartitions(c Config) error {
+	logInfo("formatPartitions: starting partition mode")
+	logInfo("formatPartitions: root=%s, boot=%s", c.RootPartition, c.BootPartition)
+
+	// Format root partition with XFS
+	logInfo("formatPartitions: formatting %s with XFS", c.RootPartition)
+	if _, err := runCommand("mkfs.xfs", "-f", c.RootPartition); err != nil {
+		return fmt.Errorf("mkfs.xfs %s: %w", c.RootPartition, err)
+	}
+
+	// Mount root partition
+	logInfo("formatPartitions: mounting %s at /mnt", c.RootPartition)
+	os.MkdirAll("/mnt", 0755)
+	if _, err := runCommand("mount", c.RootPartition, "/mnt"); err != nil {
+		return fmt.Errorf("mount %s: %w", c.RootPartition, err)
+	}
+
+	// Mount boot partition
+	logInfo("formatPartitions: mounting %s at /mnt/boot", c.BootPartition)
+	os.MkdirAll("/mnt/boot", 0755)
+	if _, err := runCommand("mount", c.BootPartition, "/mnt/boot"); err != nil {
+		return fmt.Errorf("mount %s: %w", c.BootPartition, err)
+	}
+
+	logInfo("formatPartitions: completed successfully")
+	return nil
+}
+
 func formatDisk(c Config) error {
 	logInfo("formatDisk: starting")
+
+	// Partition mode: skip disko, format and mount manually
+	if c.StorageMode.usesPartitions() {
+		return formatPartitions(c)
+	}
+
 	hostDir := filepath.Join(c.WorkDir, "hosts", c.Hostname)
 	diskoConfig := filepath.Join(hostDir, "disks.nix")
 	logInfo("formatDisk: diskoConfig = %s", diskoConfig)

--- a/cmd/installer/disk.go
+++ b/cmd/installer/disk.go
@@ -44,7 +44,8 @@ func getAvailableDisks() []diskInfo {
 func getAvailablePartitions(disk string) []partitionInfo {
 	var partitions []partitionInfo
 
-	cmd := exec.Command("lsblk", "-n", "-o", "NAME,SIZE,TYPE,FSTYPE,PARTLABEL", disk)
+	// Use -p for full device paths and -l for flat list (no tree characters)
+	cmd := exec.Command("lsblk", "-n", "-l", "-p", "-o", "NAME,SIZE,TYPE,FSTYPE,PARTLABEL", disk)
 	output, err := cmd.Output()
 	if err != nil {
 		return []partitionInfo{{Path: disk + "1", Size: "500M", FSType: "vfat", Label: "EFI System"}}
@@ -63,7 +64,7 @@ func getAvailablePartitions(disk string) []partitionInfo {
 				label = strings.Join(fields[4:], " ")
 			}
 			partitions = append(partitions, partitionInfo{
-				Path:   "/dev/" + fields[0],
+				Path:   fields[0],
 				Size:   fields[1],
 				FSType: fsType,
 				Label:  label,

--- a/cmd/installer/install.go
+++ b/cmd/installer/install.go
@@ -13,7 +13,7 @@ import (
 func runInstallation(c Config) tea.Cmd {
 	return func() tea.Msg {
 		logInfo("=== Starting installation ===")
-		logInfo("Config: Username=%s, Hostname=%s, Disk=%s, StorageMode=%s, EnableSSH=%v", c.Username, c.Hostname, c.Disk, c.StorageMode, c.EnableSSH)
+		logInfo("Config: Username=%s, Hostname=%s, Disk=%s, StorageMode=%s, TUI=%v, Pentest=%v, Games=%v, EnableSSH=%v", c.Username, c.Hostname, c.Disk, c.StorageMode, c.EnableTUI, c.EnablePentest, c.EnableGames, c.EnableSSH)
 		if c.StorageMode.isMultiDisk() {
 			logInfo("Config: Disks=%v", c.Disks)
 		}
@@ -259,6 +259,11 @@ func generateHostConfig(c Config) error {
     tree
   ];
 
+  # Package sets selected during installation
+  tuinix.packages.tui = %v;
+  tuinix.packages.pentest = %v;
+  tuinix.packages.games = %v;
+
 %s
 %s%s
   boot.consoleLogLevel = 3;
@@ -273,7 +278,7 @@ func generateHostConfig(c Config) error {
   services.xserver.xkb.layout = "%s";
   console.keyMap = "%s";
 }
-`, c.Username, zfsConfig, sshConfig, bootloaderConfig, c.Locale, c.Keymap, c.ConsoleKeyMap)
+`, c.Username, c.EnableTUI, c.EnablePentest, c.EnableGames, zfsConfig, sshConfig, bootloaderConfig, c.Locale, c.Keymap, c.ConsoleKeyMap)
 
 	if err := os.WriteFile(filepath.Join(hostDir, "default.nix"), []byte(defaultNix), 0644); err != nil {
 		return fmt.Errorf("write default.nix: %w", err)

--- a/cmd/installer/install.go
+++ b/cmd/installer/install.go
@@ -263,6 +263,16 @@ func generateHostConfig(c Config) error {
 		disksContent = strings.ReplaceAll(disksContent, "{{DISK_DEVICE}}", c.Disk)
 		disksContent = strings.ReplaceAll(disksContent, "{{SPACE_BOOT}}", c.SpaceBoot)
 
+	case storageXFSPartition:
+		templateFile := filepath.Join(workDir, "templates", "disko-xfs-partition.nix")
+		templateBytes, err := os.ReadFile(templateFile)
+		if err != nil {
+			return fmt.Errorf("read xfs partition template: %w", err)
+		}
+		disksContent = string(templateBytes)
+		disksContent = strings.ReplaceAll(disksContent, "{{ROOT_PARTITION}}", c.RootPartition)
+		disksContent = strings.ReplaceAll(disksContent, "{{BOOT_PARTITION}}", c.BootPartition)
+
 	case storageZFSEncryptedSingle:
 		templateFile := filepath.Join(workDir, "templates", "disko-template.nix")
 		templateBytes, err := os.ReadFile(templateFile)

--- a/cmd/installer/install.go
+++ b/cmd/installer/install.go
@@ -63,6 +63,24 @@ func runInstallation(c Config) tea.Cmd {
 			logInfo("Step %d complete", step)
 		}
 
+		if c.StorageMode.usesPartitions() {
+			logInfo("Step %d: Reinstalling GRUB bootloader...", step+1)
+			if err := configurePartitionBoot(c); err != nil {
+				logError("configurePartitionBoot failed: %v", err)
+				return installErrMsg{err: fmt.Errorf("configure partition boot: %w", err)}
+			}
+			step++
+			logInfo("Step %d complete", step)
+		}
+
+		logInfo("Step %d: Copying flake...", step+1)
+		if err := copyFlake(c); err != nil {
+			logError("copyFlake failed: %v", err)
+			return installErrMsg{err: fmt.Errorf("copy flake: %w", err)}
+		}
+		step++
+		logInfo("Step %d complete", step)
+
 		logInfo("Step %d: Setting up user flake...", step+1)
 		if err := setupUserFlake(c); err != nil {
 			logError("setupUserFlake failed: %v", err)
@@ -199,6 +217,17 @@ func generateHostConfig(c Config) error {
 		zfsConfig = `  tuinix.zfs.enable = false;`
 	}
 
+	// For dual-boot partition mode, override bootloader to avoid GRUB module conflicts
+	// on shared ESP. Install to NixOS-specific EFI directory instead of fallback path.
+	var bootloaderConfig string
+	if c.StorageMode.usesPartitions() {
+		bootloaderConfig = `
+
+  # Dual-boot: install GRUB to its own EFI directory to avoid module conflicts
+  boot.loader.grub.efiInstallAsRemovable = lib.mkForce false;
+  boot.loader.efi.canTouchEfiVariables = true;`
+	}
+
 	var sshConfig string
 	if c.EnableSSH {
 		sshConfig = `
@@ -231,7 +260,7 @@ func generateHostConfig(c Config) error {
   ];
 
 %s
-%s
+%s%s
   boot.consoleLogLevel = 3;
 
   # Enable NetworkManager for network management (provides nmtui)
@@ -244,7 +273,7 @@ func generateHostConfig(c Config) error {
   services.xserver.xkb.layout = "%s";
   console.keyMap = "%s";
 }
-`, c.Username, zfsConfig, sshConfig, c.Locale, c.Keymap, c.ConsoleKeyMap)
+`, c.Username, zfsConfig, sshConfig, bootloaderConfig, c.Locale, c.Keymap, c.ConsoleKeyMap)
 
 	if err := os.WriteFile(filepath.Join(hostDir, "default.nix"), []byte(defaultNix), 0644); err != nil {
 		return fmt.Errorf("write default.nix: %w", err)
@@ -403,6 +432,39 @@ func configureZFSBoot(c Config) error {
 
 	if strings.TrimSpace(output) != bootfsPath {
 		return fmt.Errorf("bootfs not set correctly, got: %s", output)
+	}
+
+	return nil
+}
+
+func configurePartitionBoot(c Config) error {
+	// Remove conflicting GRUB modules from shared ESP left by another OS (e.g. CachyOS).
+	// NixOS GRUB with os-prober will regenerate the config detecting all OSes.
+	logInfo("configurePartitionBoot: cleaning old GRUB modules from shared ESP")
+	runCommand("rm", "-rf", "/mnt/boot/grub")
+
+	// Reinstall GRUB from within the installed system to ensure module consistency
+	logInfo("configurePartitionBoot: reinstalling GRUB via nixos-enter")
+	if _, err := runCommand("nixos-enter", "--root", "/mnt", "--command",
+		"/run/current-system/bin/switch-to-configuration boot"); err != nil {
+		return fmt.Errorf("reinstall bootloader: %w", err)
+	}
+
+	return nil
+}
+
+func copyFlake(c Config) error {
+	targetDir := "/mnt/etc/tuinix"
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("create target dir: %w", err)
+	}
+
+	if _, err := runCommand("cp", "-r", c.WorkDir+"/.", targetDir+"/"); err != nil {
+		return fmt.Errorf("copy flake: %w", err)
+	}
+
+	if _, err := runCommand("chown", "-R", "root:root", targetDir); err != nil {
+		return fmt.Errorf("chown: %w", err)
 	}
 
 	return nil

--- a/cmd/installer/model.go
+++ b/cmd/installer/model.go
@@ -39,6 +39,7 @@ func initialModel() model {
 			{Label: "fr", XKBLayout: "fr", ConsoleMap: "fr-latin1"},
 			{Label: "es", XKBLayout: "es", ConsoleMap: "es"},
 		},
+		pkgSelected: make([]bool, len(packageOptions)),
 		config: Config{
 			ZFSPoolName: "NIXROOT",
 			SpaceBoot:   "5G",
@@ -102,7 +103,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only allow q to quit on non-input screens (splash, disk selection, locale, keymap, ssh, summary, complete, error)
 			// Text input states must pass q through to the input field
 			switch m.state {
-			case stateSplash, stateNetworkCheck, stateDisk, stateDiskMulti, statePartitionBoot, statePartitionRoot, stateLocale, stateKeymap, stateSSH, stateSummary, stateStorageMode, stateComplete, stateError:
+			case stateSplash, stateNetworkCheck, stateDisk, stateDiskMulti, statePartitionBoot, statePartitionRoot, stateLocale, stateKeymap, statePackageSet, stateSSH, stateSummary, stateStorageMode, stateComplete, stateError:
 				return m, tea.Quit
 			}
 		case "enter":
@@ -110,12 +111,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.handleEnter()
 			}
 		case " ":
-			// Space toggles disk selection in multi-disk mode
 			if m.state == stateDiskMulti && m.selectedIdx < len(m.disks) {
 				m.diskSelected[m.selectedIdx] = !m.diskSelected[m.selectedIdx]
+			} else if m.state == statePackageSet && m.selectedIdx < len(m.pkgSelected) {
+				m.pkgSelected[m.selectedIdx] = !m.pkgSelected[m.selectedIdx]
 			}
 		case "up", "k":
-			if m.state == stateDisk || m.state == stateDiskMulti || m.state == statePartitionBoot || m.state == statePartitionRoot || m.state == stateLocale || m.state == stateKeymap || m.state == stateSSH || m.state == stateStorageMode {
+			if m.state == stateDisk || m.state == stateDiskMulti || m.state == statePartitionBoot || m.state == statePartitionRoot || m.state == stateLocale || m.state == stateKeymap || m.state == statePackageSet || m.state == stateSSH || m.state == stateStorageMode {
 				if m.selectedIdx > 0 {
 					m.selectedIdx--
 				}
@@ -132,6 +134,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else if m.state == stateLocale && m.selectedIdx < len(m.locales)-1 {
 				m.selectedIdx++
 			} else if m.state == stateKeymap && m.selectedIdx < len(m.keymaps)-1 {
+				m.selectedIdx++
+			} else if m.state == statePackageSet && m.selectedIdx < len(packageOptions)-1 {
 				m.selectedIdx++
 			} else if m.state == stateSSH && m.selectedIdx < 1 {
 				m.selectedIdx++
@@ -505,6 +509,13 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 		m.config.Keymap = km.XKBLayout
 		m.config.ConsoleKeyMap = km.ConsoleMap
 		calculateSpaceAllocation(&m.config)
+		m.state = statePackageSet
+		m.selectedIdx = 0
+
+	case statePackageSet:
+		m.config.EnableTUI = m.pkgSelected[0]
+		m.config.EnablePentest = m.pkgSelected[1]
+		m.config.EnableGames = m.pkgSelected[2]
 		m.state = stateSSH
 		m.selectedIdx = 0
 

--- a/cmd/installer/model.go
+++ b/cmd/installer/model.go
@@ -102,7 +102,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only allow q to quit on non-input screens (splash, disk selection, locale, keymap, ssh, summary, complete, error)
 			// Text input states must pass q through to the input field
 			switch m.state {
-			case stateSplash, stateNetworkCheck, stateDisk, stateDiskMulti, stateLocale, stateKeymap, stateSSH, stateSummary, stateStorageMode, stateComplete, stateError:
+			case stateSplash, stateNetworkCheck, stateDisk, stateDiskMulti, statePartitionBoot, statePartitionRoot, stateLocale, stateKeymap, stateSSH, stateSummary, stateStorageMode, stateComplete, stateError:
 				return m, tea.Quit
 			}
 		case "enter":
@@ -115,7 +115,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.diskSelected[m.selectedIdx] = !m.diskSelected[m.selectedIdx]
 			}
 		case "up", "k":
-			if m.state == stateDisk || m.state == stateDiskMulti || m.state == stateLocale || m.state == stateKeymap || m.state == stateSSH || m.state == stateStorageMode {
+			if m.state == stateDisk || m.state == stateDiskMulti || m.state == statePartitionBoot || m.state == statePartitionRoot || m.state == stateLocale || m.state == stateKeymap || m.state == stateSSH || m.state == stateStorageMode {
 				if m.selectedIdx > 0 {
 					m.selectedIdx--
 				}
@@ -124,6 +124,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == stateDisk && m.selectedIdx < len(m.disks)-1 {
 				m.selectedIdx++
 			} else if m.state == stateDiskMulti && m.selectedIdx < len(m.disks)-1 {
+				m.selectedIdx++
+			} else if m.state == statePartitionBoot && m.selectedIdx < len(m.partitions)-1 {
+				m.selectedIdx++
+			} else if m.state == statePartitionRoot && m.selectedIdx < len(m.partitions)-1 {
 				m.selectedIdx++
 			} else if m.state == stateLocale && m.selectedIdx < len(m.locales)-1 {
 				m.selectedIdx++
@@ -397,20 +401,49 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 			m.config.Disk = m.disks[m.selectedIdx].Path
 			m.config.Disks = []string{m.config.Disk}
 			m.config.HostID = generateHostID()
-			if m.config.StorageMode.isEncrypted() {
+			if m.config.StorageMode.usesPartitions() {
+				// Partition mode: load partitions from selected disk, go to boot partition selection
+				m.partitions = getAvailablePartitions(m.config.Disk)
+				m.selectedIdx = 0
+				m.state = statePartitionBoot
+			} else if m.config.StorageMode.isEncrypted() {
 				m.state = statePassphrase
 				m.input.SetValue("")
 				m.input.Placeholder = "Enter ZFS encryption passphrase"
 				m.input.EchoMode = textinput.EchoPassword
 				m.input.EchoCharacter = '*'
 			} else {
-				// XFS mode: skip passphrase, go to locale
+				// XFS whole-disk mode: skip passphrase, go to locale
 				m.state = stateLocale
 				m.input.SetValue("")
 				m.input.EchoMode = textinput.EchoNormal
 				m.input.EchoCharacter = 0
 				m.selectedIdx = 0
 			}
+		}
+
+	case statePartitionBoot:
+		if len(m.partitions) > 0 {
+			m.config.BootPartition = m.partitions[m.selectedIdx].Path
+			m.err = nil
+			m.selectedIdx = 0
+			m.state = statePartitionRoot
+		}
+
+	case statePartitionRoot:
+		if len(m.partitions) > 0 {
+			selected := m.partitions[m.selectedIdx]
+			if selected.Path == m.config.BootPartition {
+				m.err = fmt.Errorf("root partition must be different from boot partition (%s)", m.config.BootPartition)
+				return m, nil
+			}
+			m.config.RootPartition = selected.Path
+			m.err = nil
+			m.state = stateLocale
+			m.input.SetValue("")
+			m.input.EchoMode = textinput.EchoNormal
+			m.input.EchoCharacter = 0
+			m.selectedIdx = 0
 		}
 
 	case stateDiskMulti:

--- a/cmd/installer/render.go
+++ b/cmd/installer/render.go
@@ -219,6 +219,28 @@ func (m model) renderRightPanel(stepNum int) string {
 		hint := grayStyle.Render("\nSpace to toggle | Up/Down to move | Enter to confirm")
 		content = warning + "\n" + statusStyle.Render(status) + "\n\n" + diskList.String() + errText + hint
 
+	case statePackageSet:
+		baseStyle := lipgloss.NewStyle().Foreground(colorGreen)
+		content = baseStyle.Render("[x] Minimal (always installed)") + "\n"
+		content += grayStyle.Render("    vim, git, curl, htop, tmux, wget, tree") + "\n\n"
+
+		for i, opt := range packageOptions {
+			cursor := "  "
+			check := "[ ]"
+			style := lipgloss.NewStyle().Foreground(colorOffWhite)
+			if i == m.selectedIdx {
+				cursor = "> "
+				style = style.Foreground(colorOrange).Bold(true)
+			}
+			if m.pkgSelected[i] {
+				check = "[x]"
+			}
+			content += style.Render(cursor+check+" "+opt.Label) + "\n"
+			content += grayStyle.Render("    "+opt.Desc) + "\n\n"
+		}
+		hint := grayStyle.Render("[Space] Toggle | [Up/Down] Move | [Enter] Next")
+		content += hint
+
 	case stateSSH:
 		sshOptions := []struct {
 			label string
@@ -325,6 +347,7 @@ func (m model) renderRightPanel(stepNum int) string {
 			infoStyle.Render(fmt.Sprintf("  Host ID:   %s", m.config.HostID)) + "\n" +
 			infoStyle.Render(fmt.Sprintf("  Locale:    %s", m.config.Locale)) + "\n" +
 			infoStyle.Render(fmt.Sprintf("  Keyboard:  %s", m.config.Keymap)) + "\n" +
+			infoStyle.Render(fmt.Sprintf("  Packages:  %s", formatPackageSets(m.config))) + "\n" +
 			infoStyle.Render(fmt.Sprintf("  SSH:       %s", sshStatus)) +
 			sshExtra + "\n\n" +
 			allocSection + "\n\n" +
@@ -332,6 +355,20 @@ func (m model) renderRightPanel(stepNum int) string {
 	}
 
 	return content
+}
+
+func formatPackageSets(c Config) string {
+	sets := []string{"Minimal"}
+	if c.EnableTUI {
+		sets = append(sets, "TUI")
+	}
+	if c.EnablePentest {
+		sets = append(sets, "Pentest")
+	}
+	if c.EnableGames {
+		sets = append(sets, "Games")
+	}
+	return strings.Join(sets, " + ")
 }
 
 func (m model) getInstallStepNames() []string {

--- a/cmd/installer/render.go
+++ b/cmd/installer/render.go
@@ -127,6 +127,59 @@ func (m model) renderRightPanel(stepNum int) string {
 		hint := grayStyle.Render("\nUp/Down to select | Enter to confirm")
 		content = warning + "\n\n" + diskList.String() + hint
 
+	case statePartitionBoot:
+		var partList strings.Builder
+		for i, part := range m.partitions {
+			cursor := "  "
+			style := lipgloss.NewStyle().Foreground(colorOffWhite)
+			if i == m.selectedIdx {
+				cursor = "> "
+				style = style.Foreground(colorOrange).Bold(true)
+			}
+			line := fmt.Sprintf("%s%-12s %8s  %s", cursor, part.Path, part.Size, part.FSType)
+			partList.WriteString(style.Render(line))
+			partList.WriteString("\n")
+			if part.Label != "" {
+				partList.WriteString(grayStyle.Render("   " + part.Label))
+				partList.WriteString("\n")
+			}
+		}
+
+		note := grayStyle.Render("Select the EFI/boot partition (typically vfat)")
+		hint := grayStyle.Render("\nUp/Down to select | Enter to confirm")
+		content = note + "\n\n" + partList.String() + hint
+
+	case statePartitionRoot:
+		var partList strings.Builder
+		for i, part := range m.partitions {
+			cursor := "  "
+			style := lipgloss.NewStyle().Foreground(colorOffWhite)
+			if i == m.selectedIdx {
+				cursor = "> "
+				style = style.Foreground(colorOrange).Bold(true)
+			}
+			// Indicate which partition is already selected as boot
+			bootMarker := ""
+			if part.Path == m.config.BootPartition {
+				bootMarker = " [boot]"
+			}
+			line := fmt.Sprintf("%s%-12s %8s  %s%s", cursor, part.Path, part.Size, part.FSType, bootMarker)
+			partList.WriteString(style.Render(line))
+			partList.WriteString("\n")
+			if part.Label != "" {
+				partList.WriteString(grayStyle.Render("   " + part.Label))
+				partList.WriteString("\n")
+			}
+		}
+
+		warning := errorStyle.Render("! This partition will be formatted with XFS!")
+		var errText string
+		if m.err != nil {
+			errText = "\n" + errorStyle.Render("! "+m.err.Error())
+		}
+		hint := grayStyle.Render("\nUp/Down to select | Enter to confirm")
+		content = warning + "\n\n" + partList.String() + errText + hint
+
 	case stateDiskMulti:
 		var diskList strings.Builder
 		selectedCount := 0
@@ -225,7 +278,11 @@ func (m model) renderRightPanel(stepNum int) string {
 
 		// Build disk info section
 		var diskInfo string
-		if m.config.StorageMode.isMultiDisk() {
+		if m.config.StorageMode.usesPartitions() {
+			diskInfo = infoStyle.Render(fmt.Sprintf("  Disk:      %s", m.config.Disk)) + "\n" +
+				infoStyle.Render(fmt.Sprintf("  Boot part: %s", m.config.BootPartition)) + "\n" +
+				infoStyle.Render(fmt.Sprintf("  Root part: %s", m.config.RootPartition))
+		} else if m.config.StorageMode.isMultiDisk() {
 			diskInfo = infoStyle.Render(fmt.Sprintf("  Disks:     %s", strings.Join(m.config.Disks, ", ")))
 		} else {
 			diskInfo = infoStyle.Render(fmt.Sprintf("  Disk:      %s", m.config.Disk))
@@ -233,7 +290,11 @@ func (m model) renderRightPanel(stepNum int) string {
 
 		// Build storage allocation section
 		var allocSection string
-		if m.config.StorageMode.isZFS() {
+		if m.config.StorageMode.usesPartitions() {
+			allocSection = promptStyle.Render("Partition Layout") + "\n" +
+				infoStyle.Render(fmt.Sprintf("  /boot:      %s (existing)", m.config.BootPartition)) + "\n" +
+				infoStyle.Render(fmt.Sprintf("  /:          %s (XFS)", m.config.RootPartition))
+		} else if m.config.StorageMode.isZFS() {
 			allocSection = promptStyle.Render("Disk Allocation") + "\n" +
 				infoStyle.Render(fmt.Sprintf("  /boot:      %s", m.config.SpaceBoot)) + "\n" +
 				infoStyle.Render(fmt.Sprintf("  /nix:       %s", m.config.SpaceNix)) + "\n" +
@@ -284,6 +345,17 @@ func (m model) getInstallStepNames() []string {
 			"Setting up user flake",
 			"Copying install log",
 			"Finalizing ZFS pool",
+		}
+	}
+	if m.config.StorageMode.usesPartitions() {
+		return []string{
+			"Generating host configuration",
+			"Formatting root partition with XFS",
+			"Generating hardware configuration",
+			"Installing NixOS",
+			"Copying flake to new system",
+			"Setting up user flake",
+			"Copying install log",
 		}
 	}
 	return []string{

--- a/cmd/installer/render.go
+++ b/cmd/installer/render.go
@@ -353,6 +353,7 @@ func (m model) getInstallStepNames() []string {
 			"Formatting root partition with XFS",
 			"Generating hardware configuration",
 			"Installing NixOS",
+			"Reinstalling GRUB bootloader",
 			"Copying flake to new system",
 			"Setting up user flake",
 			"Copying install log",

--- a/cmd/installer/types.go
+++ b/cmd/installer/types.go
@@ -91,6 +91,7 @@ const (
 	statePassphraseConfirm
 	stateLocale
 	stateKeymap
+	statePackageSet
 	stateSSH
 	stateGitHubUser
 	stateSummary
@@ -344,6 +345,33 @@ Common layouts:
 • fr - French (AZERTY)`,
 		stepNum: 12,
 	},
+	statePackageSet: {
+		title: "Package Sets",
+		description: `Select additional package sets to install.
+
+The base system (vim, git, curl, htop,
+tmux, wget, tree) is always included.
+
+Use Space to toggle each option:
+
+TUI Productivity Suite:
+  Terminal apps for daily work. neovim,
+  helix, lazygit, btop, nchat, w3m,
+  starship, atuin, zellij.
+
+Pentest Tools:
+  Security auditing and penetration
+  testing. aircrack-ng, nmap, metasploit,
+  wireshark, hashcat, sqlmap.
+
+Terminal Games:
+  Best-of-breed terminal games. Roguelikes,
+  puzzles, arcade, text adventures.
+
+You can always add/remove packages later
+via your NixOS configuration.`,
+		stepNum: 13,
+	},
 	stateSSH: {
 		title: "SSH Server",
 		description: `Choose whether to enable the SSH server
@@ -365,7 +393,7 @@ so we can fetch your public SSH keys.
 Recommended for servers and headless
 machines. You can change this later in
 your NixOS configuration.`,
-		stepNum: 13,
+		stepNum: 14,
 	},
 	stateGitHubUser: {
 		title: "GitHub Username",
@@ -383,7 +411,7 @@ GitHub SSH keys.
 Password authentication will be disabled,
 so key-based access is the only way to
 log in remotely.`,
-		stepNum: 14,
+		stepNum: 15,
 	},
 	stateSummary: {
 		title: "Review Configuration",
@@ -399,7 +427,7 @@ After confirmation, the installer will:
 This process takes 10-30 minutes
 depending on your hardware and
 internet connection speed.`,
-		stepNum: 15,
+		stepNum: 16,
 	},
 	stateConfirm: {
 		title: "Final Confirmation",
@@ -412,11 +440,23 @@ This action cannot be undone.
 
 To proceed, type DESTROY exactly.
 To cancel, press Ctrl+C or q.`,
-		stepNum: 16,
+		stepNum: 17,
 	},
 }
 
-const totalSteps = 16
+const totalSteps = 17
+
+// Package set options (checkboxes -- minimal is always on)
+type packageOption struct {
+	Label string
+	Desc  string
+}
+
+var packageOptions = []packageOption{
+	{"TUI productivity suite", "neovim, helix, lazygit, btop, nchat, w3m, starship, atuin, zellij"},
+	{"Pentest tools", "aircrack-ng, nmap, metasploit, wireshark, termshark, hashcat, sqlmap"},
+	{"Terminal games", "angband, crawl, cataclysm-dda, vitetris, nudoku, frotz, bsdgames"},
+}
 
 // Config holds all installation configuration
 type Config struct {
@@ -433,8 +473,9 @@ type Config struct {
 	Locale        string
 	Keymap        string
 	ConsoleKeyMap string
-	EnableTUI     bool // Install TUI productivity suite
-	EnableGUI     bool // Install minimal GUI (Sway + Brave)
+	EnableTUI     bool
+	EnablePentest bool
+	EnableGames   bool
 	EnableSSH     bool
 	GitHubUser    string
 	SSHKeys       []string
@@ -505,6 +546,7 @@ type model struct {
 	partitions   []partitionInfo // Available partitions on selected disk
 	selectedIdx  int
 	diskSelected []bool // For multi-disk selection (toggle with space)
+	pkgSelected  []bool // For package set checkboxes [TUI, Pentest, Games]
 	locales      []string
 	keymaps      []keymapEntry
 

--- a/cmd/installer/types.go
+++ b/cmd/installer/types.go
@@ -14,6 +14,7 @@ type storageMode int
 const (
 	storageZFSEncryptedSingle storageMode = iota // Encrypted ZFS, single disk (original)
 	storageXFS                                   // XFS unencrypted, single disk (max performance)
+	storageXFSPartition                          // XFS unencrypted, existing partition (dual-boot)
 	storageZFSStripe                             // Encrypted ZFS stripe, multi-disk (combined space)
 	storageZFSRaidz                              // Encrypted ZFS raidz, multi-disk (1 disk fault tolerance)
 	storageZFSRaidz2                             // Encrypted ZFS raidz2, multi-disk (2 disk fault tolerance)
@@ -24,7 +25,9 @@ func (s storageMode) String() string {
 	case storageZFSEncryptedSingle:
 		return "Encrypted ZFS (single disk)"
 	case storageXFS:
-		return "XFS unencrypted (max performance)"
+		return "XFS unencrypted (whole disk)"
+	case storageXFSPartition:
+		return "XFS unencrypted (existing partition)"
 	case storageZFSStripe:
 		return "Encrypted ZFS stripe (combined space)"
 	case storageZFSRaidz:
@@ -37,11 +40,15 @@ func (s storageMode) String() string {
 }
 
 func (s storageMode) isZFS() bool {
-	return s != storageXFS
+	return s != storageXFS && s != storageXFSPartition
 }
 
 func (s storageMode) isEncrypted() bool {
-	return s != storageXFS
+	return s != storageXFS && s != storageXFSPartition
+}
+
+func (s storageMode) usesPartitions() bool {
+	return s == storageXFSPartition
 }
 
 func (s storageMode) isMultiDisk() bool {
@@ -78,6 +85,8 @@ const (
 	stateStorageMode
 	stateDisk
 	stateDiskMulti
+	statePartitionBoot
+	statePartitionRoot
 	statePassphrase
 	statePassphraseConfirm
 	stateLocale
@@ -101,6 +110,7 @@ type stepInfo struct {
 var storageModes = []storageMode{
 	storageZFSEncryptedSingle,
 	storageXFS,
+	storageXFSPartition,
 	storageZFSStripe,
 	storageZFSRaidz,
 	storageZFSRaidz2,
@@ -108,7 +118,8 @@ var storageModes = []storageMode{
 
 var storageModeDescriptions = map[storageMode]string{
 	storageZFSEncryptedSingle: "Single disk with AES-256-GCM encryption, compression, and snapshots",
-	storageXFS:                "Single disk, no encryption. Maximum raw I/O performance",
+	storageXFS:                "Whole disk, no encryption. Maximum raw I/O performance",
+	storageXFSPartition:       "Install on existing partitions. For dual-boot or pre-partitioned disks",
 	storageZFSStripe:          "Multiple disks combined for maximum space (no redundancy)",
 	storageZFSRaidz:           "Multiple disks with single parity. Tolerates 1 disk failure (min 3 disks)",
 	storageZFSRaidz2:          "Multiple disks with double parity. Tolerates 2 disk failures (min 4 disks)",
@@ -205,7 +216,10 @@ Use only letters, numbers, and hyphens.`,
 Single disk options:
 • Encrypted ZFS - Secure, with snapshots
   and compression (recommended)
-• XFS - Maximum performance, no encryption
+• XFS (whole disk) - Maximum performance,
+  no encryption, erases entire disk
+• XFS (existing partition) - Install on
+  pre-existing partitions for dual-boot
 
 Multi-disk options (requires 2+ disks):
 • ZFS Stripe - Combines all disks into one
@@ -242,6 +256,36 @@ the EFI boot partition.
 
 Press Enter when done selecting.`,
 		stepNum: 8,
+	},
+	statePartitionBoot: {
+		title: "Boot Partition",
+		description: `Select the existing boot/ESP partition.
+
+This should be an EFI System Partition
+(typically formatted as FAT32/vfat).
+
+The boot partition will NOT be reformatted.
+It must already contain a valid filesystem.
+
+Look for partitions with type "vfat" or
+"EFI System" — they are typically 100MB
+to 1GB in size.`,
+		stepNum: 9,
+	},
+	statePartitionRoot: {
+		title: "Root Partition",
+		description: `Select the partition for the root filesystem.
+
+WARNING: This partition will be formatted
+with XFS! All existing data on this
+partition will be destroyed.
+
+Other partitions on the disk will NOT
+be touched.
+
+Choose a partition large enough for the
+operating system (minimum 20GB recommended).`,
+		stepNum: 10,
 	},
 	statePassphrase: {
 		title: "ZFS Encryption Passphrase",
@@ -389,6 +433,8 @@ type Config struct {
 	Locale        string
 	Keymap        string
 	ConsoleKeyMap string
+	EnableTUI     bool // Install TUI productivity suite
+	EnableGUI     bool // Install minimal GUI (Sway + Brave)
 	EnableSSH     bool
 	GitHubUser    string
 	SSHKeys       []string
@@ -400,6 +446,8 @@ type Config struct {
 	DisplayRes    string // Detected framebuffer resolution (e.g. "1920x1080")
 	ProjectRoot   string
 	WorkDir       string
+	BootPartition string // Boot/ESP partition path for partition mode
+	RootPartition string // Root partition path for partition mode
 }
 
 // Particle for fire effect
@@ -430,6 +478,13 @@ type diskInfo struct {
 	Model string
 }
 
+type partitionInfo struct {
+	Path   string // e.g., /dev/sda1
+	Size   string // human-readable size
+	FSType string // e.g., vfat, ext4, xfs, ""
+	Label  string // partition label (e.g., EFI System)
+}
+
 type keymapEntry struct {
 	Label      string // Display label (e.g. "us", "pt")
 	XKBLayout  string // X11/Wayland layout (e.g. "us", "pt")
@@ -447,6 +502,7 @@ type model struct {
 	viewport     viewport.Model
 	err          error
 	disks        []diskInfo
+	partitions   []partitionInfo // Available partitions on selected disk
 	selectedIdx  int
 	diskSelected []bool // For multi-disk selection (toggle with space)
 	locales      []string

--- a/docs/installation/bare-metal.md
+++ b/docs/installation/bare-metal.md
@@ -157,7 +157,7 @@ The interactive TUI installer will guide you through:
 
 ## Storage Modes
 
-The installer supports five storage modes:
+The installer supports six storage modes:
 
 ### Encrypted ZFS (single disk) -- recommended
 
@@ -171,6 +171,23 @@ A single disk with an EFI boot partition and an XFS root partition. No encryptio
 overhead. This gives maximum raw I/O performance and uses the latest available kernel
 (not constrained by ZFS compatibility). Choose this when performance matters more than
 encryption or ZFS features.
+
+### XFS unencrypted (existing partition) -- dual-boot
+
+Install tuinix on pre-existing partitions without erasing the entire disk. This is ideal
+for dual-boot setups or machines with a pre-partitioned disk layout. You select an existing
+boot/ESP partition and an existing root partition:
+
+- The **boot/ESP partition** is used as-is (not reformatted) -- it must already contain a valid FAT32 filesystem
+- The **root partition** is formatted with XFS -- all existing data on this partition will be destroyed
+- Other partitions on the disk are left untouched
+
+!!! tip "Preparing partitions"
+    Before running the installer, use a partitioning tool (e.g. `fdisk`, `gdisk`, or `parted`)
+    to create the partitions you need. You need at least:
+
+    - An EFI System Partition (ESP) of at least 100 MB, formatted as FAT32
+    - A root partition of at least 20 GB for the operating system
 
 ### Encrypted ZFS stripe (multi-disk) -- combined space
 
@@ -250,6 +267,17 @@ ZFS datasets created:
 |-----------|------|------------|---------|
 | ESP | 5 GB | FAT32 | EFI System Partition (`/boot`) |
 | Root | Remainder | XFS | Root filesystem (`/`) |
+
+### XFS unencrypted (existing partition)
+
+Uses pre-existing partitions selected by the user. Only the root partition is formatted.
+
+| Partition | Action | Filesystem | Purpose |
+|-----------|--------|------------|---------|
+| Boot/ESP (user-selected) | Mounted (not reformatted) | FAT32 | EFI System Partition (`/boot`) |
+| Root (user-selected) | Formatted with XFS | XFS | Root filesystem (`/`) |
+
+All other partitions on the disk remain untouched.
 
 ### Multi-disk ZFS (stripe, raidz, raidz2)
 

--- a/docs/installation/bare-metal.md
+++ b/docs/installation/bare-metal.md
@@ -181,6 +181,8 @@ boot/ESP partition and an existing root partition:
 - The **boot/ESP partition** is used as-is (not reformatted) -- it must already contain a valid FAT32 filesystem
 - The **root partition** is formatted with XFS -- all existing data on this partition will be destroyed
 - Other partitions on the disk are left untouched
+- GRUB is installed to its own EFI directory (`/boot/EFI/NixOS/`) so it does not conflict with existing bootloaders
+- GRUB `os-prober` auto-detects other operating systems on the machine
 
 !!! tip "Preparing partitions"
     Before running the installer, use a partitioning tool (e.g. `fdisk`, `gdisk`, or `parted`)
@@ -405,9 +407,5 @@ If your system won't boot:
 | "no such pool available" | Disk has no `/dev/disk/by-id/` entry | Rare on real hardware; check disk WWN with `ls -la /dev/disk/by-id/` |
 | Installation fails | Not enough disk space | Need at least 20 GB free |
 | Can't type passphrase | Wrong keyboard layout in initrd | Reinstall with correct keyboard layout |
-| "path not found" during offline install | Custom packages not in ISO closure | Connect to internet or rebuild ISO with custom packages |
-
-!!! tip "Offline Installation Notes"
-    The ISO includes all standard tuinix packages. If you modify the
-    configuration to add packages not in the standard set, you may need
-    an internet connection or to rebuild the ISO with your custom closure.
+| "path not found" during install | Package not available in cache | Check internet connection and retry |
+| `grub_is_shim_lock_enabled` error | GRUB module version conflict on shared ESP | Boot from USB, chroot in, run `rm -rf /boot/grub && nixos-rebuild boot --flake /etc/tuinix#<hostname>` |

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -2,5 +2,5 @@
 { lib, ... }:
 
 {
-  imports = [ ./system ./security ./networking ];
+  imports = [ ./system ./security ./networking ./locale ../software ];
 }

--- a/modules/locale/default.nix
+++ b/modules/locale/default.nix
@@ -1,6 +1,8 @@
-# System-level configuration modules
+# Default locale configuration
+# Individual locale files (en_US.nix, pt_PT.nix) serve as templates
+# that hosts can import directly to override these defaults.
 { lib, ... }:
 
 {
-  imports = [ ./en_US.nix ./pt_PT.nix ];
+  imports = [ ./en_US.nix ];
 }

--- a/software/default.nix
+++ b/software/default.nix
@@ -1,6 +1,7 @@
-# Software packages organized by category
-{ lib, ... }:
+# Software package sets for tuinix
+# Selected during installation via the package set chooser
+{ lib, config, ... }:
 
 {
-  imports = [ ./terminal ./system ./security ];
+  imports = [ ./minimal.nix ./tui.nix ./pentest.nix ./games.nix ];
 }

--- a/software/games.nix
+++ b/software/games.nix
@@ -1,0 +1,35 @@
+# Games package set -- best-of-breed terminal games across genres
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = mkIf config.tuinix.packages.games {
+    environment.systemPackages = with pkgs; [
+      # Roguelikes
+      angband # Classic Tolkien-themed dungeon crawler
+      crawl # Dungeon Crawl Stone Soup - deep tactical roguelike
+      cataclysm-dda # Post-apocalyptic survival roguelike
+
+      # Puzzle games
+      nudoku # Terminal sudoku
+      greed # Eat as much as you can (number puzzle)
+      bastet # Tetris clone that plays against you
+
+      # Arcade / action
+      nsnake # Classic snake game
+      moon-buggy # Drive a buggy across the moon
+      ninvaders # Space Invaders clone
+      vitetris # Multiplayer terminal Tetris
+
+      # Card and board games
+      tty-solitaire # Klondike solitaire
+      gnugo # GNU Go - play Go against the computer
+      bsdgames # Collection of classic text games (adventure, worm, snake, etc.)
+
+      # Text adventures
+      frotz # Z-machine interpreter (play Zork and thousands of interactive fiction games)
+      open-adventure # Colossal Cave Adventure - the original text adventure
+    ];
+  };
+}

--- a/software/minimal.nix
+++ b/software/minimal.nix
@@ -8,7 +8,10 @@ with lib;
   options.tuinix.packages = {
     tui = mkEnableOption
       "TUI productivity suite (terminal apps for messaging, browsing, productivity)";
-    gui = mkEnableOption "Minimal GUI (Sway, Brave browser, PipeWire audio)";
+    pentest = mkEnableOption
+      "Pentest tools (aircrack-ng, nmap, metasploit, wireshark, hashcat)";
+    games = mkEnableOption
+      "Terminal games (roguelikes, puzzles, classics, text adventures)";
   };
 
   config = {

--- a/software/pentest.nix
+++ b/software/pentest.nix
@@ -1,0 +1,35 @@
+# Pentest package set -- TUI-based penetration testing and security auditing tools
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = mkIf config.tuinix.packages.pentest {
+    environment.systemPackages = with pkgs; [
+      # Wireless auditing
+      aircrack-ng
+      airgorah
+      iw
+      wirelesstools
+      macchanger
+
+      # Network analysis
+      wireshark-cli
+      termshark
+      nmap
+
+      # Exploitation frameworks
+      metasploit
+
+      # Web application testing
+      sqlmap
+      zap
+
+      # Password recovery
+      hashcat
+
+      # Utilities
+      jq
+    ];
+  };
+}

--- a/software/terminal/default.nix
+++ b/software/terminal/default.nix
@@ -1,4 +1,0 @@
-# Terminal-focused software packages
-{ pkgs, ... }:
-
-{ }

--- a/templates/disko-xfs-partition.nix
+++ b/templates/disko-xfs-partition.nix
@@ -1,0 +1,20 @@
+# Filesystem configuration for existing partition XFS install
+# Does not use disko device management - uses NixOS fileSystems directly
+# Variables to be interpolated:
+# - {{ROOT_PARTITION}} - Root partition device (e.g., /dev/sda3)
+# - {{BOOT_PARTITION}} - Boot/ESP partition device (e.g., /dev/sda1)
+
+{ lib, ... }:
+{
+  fileSystems = {
+    "/" = {
+      device = "{{ROOT_PARTITION}}";
+      fsType = "xfs";
+    };
+    "/boot" = {
+      device = "{{BOOT_PARTITION}}";
+      fsType = "vfat";
+      options = [ "umask=0077" ];
+    };
+  };
+}

--- a/templates/disko-xfs-partition.nix
+++ b/templates/disko-xfs-partition.nix
@@ -4,8 +4,7 @@
 # - {{ROOT_PARTITION}} - Root partition device (e.g., /dev/sda3)
 # - {{BOOT_PARTITION}} - Boot/ESP partition device (e.g., /dev/sda1)
 
-{ lib, ... }:
-{
+{ lib, ... }: {
   fileSystems = {
     "/" = {
       device = "{{ROOT_PARTITION}}";


### PR DESCRIPTION
## Summary

Replaces #12 (rebased onto current main to resolve conflicts).

Adds a new storage mode that installs tuinix onto an existing partition,
preserving the existing EFI System Partition. This enables dual-boot
setups where another OS (e.g. CachyOS, Ubuntu) already occupies the disk.

## Changes

- New storage mode: XFS on existing partition (dual-boot)
- New disko template: `templates/disko-xfs-partition.nix`
- NVMe partition path parsing fix (e.g. `/dev/nvme0n1p2` vs `/dev/sda2`)
- GRUB module conflict fix for shared ESP (cleans old GRUB modules before reinstall)
- Updated installer UI with partition selection
- Updated bare-metal docs with GRUB troubleshooting

## Original author

Dimas Ciputra (@dimasciput) - original commits from PR #12

Closes #12

## Test plan

- [ ] XFS partition mode installs alongside existing OS
- [ ] NVMe disk partition paths resolve correctly
- [ ] GRUB boots both OSes after install
- [ ] Existing storage modes (ZFS encrypted, XFS full disk) still work